### PR TITLE
Xcode 10: Attribute 'readonly' of property restricts attribute 'readwrite' of property inherited from 'CMPPaymentMethodProtocol'

### DIFF
--- a/Computop/Computop/Computop.framework/Headers/CMPPaymentMethodProtocol.h
+++ b/Computop/Computop/Computop.framework/Headers/CMPPaymentMethodProtocol.h
@@ -21,22 +21,22 @@
 /**
  Payment method id.
  */
-@property (nonatomic, strong) NSString *pmID;
+@property (nonatomic, strong, readonly) NSString *pmID;
 
 /**
  Payment method url.
  */
-@property (nonatomic, strong) NSString *url;
+@property (nonatomic, strong, readonly) NSString *url;
 
 /**
  Payment method image.
  */
-@property (nonatomic, strong) UIImage *image;
+@property (nonatomic, strong, readonly) UIImage *image;
 
 /**
  Payment method template string.
  */
-@property (nonatomic, strong) NSString *templateStr;
+@property (nonatomic, strong, readonly) NSString *templateStr;
 
 
 - (instancetype)initWithDictionary:(NSDictionary*)dictionary;


### PR DESCRIPTION
When compiling a project with Xcode 10 beta 2, the compiler fails with the following errors:

> Attribute 'readonly' of property 'pmID' restricts attribute 'readwrite' of property inherited from 'CMPPaymentMethodProtocol'
> Attribute 'readonly' of property 'url' restricts attribute 'readwrite' of property inherited from 'CMPPaymentMethodProtocol'
> Attribute 'readonly' of property 'image' restricts attribute 'readwrite' of property inherited from 'CMPPaymentMethodProtocol'
> Attribute 'readonly' of property 'templateStr' restricts attribute 'readwrite' of property inherited from 'CMPPaymentMethodProtocol'

I had to add the `readonly` attribute to these four properties of `CMPPaymentMethodProtocol` to make it compile.